### PR TITLE
Fix handling equippable items to work with Duplicate Characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,6 @@ The Github Releases mechanism is used to manually create tags/releases for users
 and use with PopTracker. The Releases archive (via `got archive`) all non-development-only files
 into .zip and .tar.gz for download. The intention is to direct users to the Releases page.
 
-It is recommended to create tags (in the form of "v.major.minor.path") along with each release,
-corresponding to bumping the version in `manifest.json` and the `changelog.txt` file with 
-brief description of updates in this release.
+It is recommended to create tags (in the form of "vmajor.minor.patch", e.g. v2.1.1) along with
+each release, corresponding to bumping the version in `manifest.json` and the `changelog.txt`
+file with brief description of updates in this release.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ v2.1.1
   - Lua file whitespace cleanup and passing luacheck
   - JSON files updated to follow strict JSON validation
   - Added README.md with Usage notes
+  - Fixed tracking equipped items to work with Duplicate Characters.
 
 v2.1.0
   - Updated for Jets of Time version 3.2


### PR DESCRIPTION
Previously encountered bug that when duplicate characters is enabled, if a frog duplicate equips Hero Medal or Grand Leon, and is not the "Frog" character (e.g. a "Marle" who is a frog duplicate), then tracker will not show the item anymore.

This fixes that by scanning all characters for the item, to work with duplicate characters flag.

NOTE: Addresses for character data was scrubbed from [Geiger's Crypt - Chrono Trigger database](http://geigercount.net/crypt/docs/Chrono%20Trigger%20Database.7z).

## Updates

* Scan all characters to see if equipped Hero Medal, Grand Leon, and Robo Rbn, to work with duplicate characters

## Testing

Tested with seed with Duplicate Characters (Marle was a frog). Previous version shows Hero Medal and Grand Leon on tracker only after removing them from character. This new version correctly shows them in tracker when they are equipped or unequipped.
