### PR TITLE
Use memory watch to handle autotracking equipable items

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ assure a measure of stability and quality with this repo.
 ## Releases
 
 The Github Releases mechanism is used to manually create tags/releases for users to download
-and use with PopTracker. The Releases archive (via `got archive`) all non-development-only files
+and use with PopTracker. The Releases archive (via `git archive`) all non-development-only files
 into .zip and .tar.gz for download. The intention is to direct users to the Releases page.
 
 It is recommended to create tags (in the form of "vmajor.minor.patch", e.g. v2.1.1) along with

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A [Chrono Trigger: Jets of Time](https://ctjot.com) tracker pack for [PopTracker
 ## Usage
 
 Download a .zip (or .tar.gz) from [the Releases page](
-https://github.com/coffeemancy/Jets-of-Time-Tracker/releases).
+https://github.com/Aeralis/Jets-of-Time-Tracker/releases).
 
 Extract this into your PopTracker packs directory per [PopTracker "Getting started"](
 https://github.com/black-sliver/PopTracker#getting-started).


### PR DESCRIPTION
Based on feedback on https://github.com/Aeralis/Jets-of-Time-Tracker/pull/5#discussion_r1285073201 moved to using a memory watch to handle equipable key items for autotracking.

## Updates

* Add `.equipped` field to `KEY_ITEMS` separately cleared/set by a memory watcher on character equipment
* Mark KI as active in tracker when it's either `.found` (from inventory) or `.equipped` (from character equipment)
* Fix to cover all 7 characters equipment
* Fix typo and link to upstream releases in README

## Testing

Tested on PopTracker (Linux) over SNI to FXPak with CT:JoT seed, moving Robo Rbn and Grand Leon back and forth in inventory and equipped (using duplicate characters, with Crono being a Robo, Marle being a Frog).

Modified "equipable" flag for those items to "false" and observed in tracker that item disappeared when moved from equipment to inventory. Came back when set back to "equipable=true".