### PR TITLE
Add support for Ice Age mode

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ v2.2.0
   - Consolidate all locations into single locations/locations.json
   - Mode-based logic in logic.lua
   - Break apart and consolidate layouts into re-usable components
+  - Add support for Ice Age mode
 
 v2.1.1
   - Removed embedded .zip file, moved to using Releases from Github

--- a/items/items.json
+++ b/items/items.json
@@ -4,49 +4,49 @@
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/crono.png",
-		"codes": "Crono"
+		"codes": "Crono,crono"
 	},
 	{
 		"name": "Lucca",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/lucca.png",
-		"codes": "Lucca"
+		"codes": "Lucca,lucca"
 	},
 	{
 		"name": "Nadia",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/marle.png",
-		"codes": "Marle,Nadia"
+		"codes": "Marle,Nadia,marle,nadia"
 	},
 	{
 		"name": "Glenn",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/frog.png",
-		"codes": "Frog,Glenn"
+		"codes": "Frog,Glenn,frog,glenn"
 	},
 	{
 		"name": "R66-Y",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/robo.png",
-		"codes": "Robo,R66-Y"
+		"codes": "Robo,R66-Y,robo"
 	},
 	{
 		"name": "Ayla",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/ayla.png",
-		"codes": "Ayla"
+		"codes": "Ayla,ayla"
 	},
 	{
 		"name": "Janus",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/magus.png",
-		"codes": "Magus,Janus"
+		"codes": "Magus,Janus,magus,janus"
 	},
 	{
 		"name": "Pendant",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -195,7 +195,7 @@
 			{
 				"name": "Dark Ages",
 				"color": "#c0c0c8",
-				"access_rules":["$lostWorldsMode", "gatekey", "rseriesboss", "magusboss"],
+				"access_rules":["$canAccessDarkAges"],
 				"children":
 				[
 					{
@@ -708,8 +708,7 @@
 					},
           {
 						"name": "Magic Cave",
-						"access_rules":
-            ["frog,masamune"],
+						"access_rules": ["$notIceAgeMode,frog,masamune"],
 						"sections":
 						[
               {

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,12 @@
     "lost_worlds_items_only": {
       "display_name": "Item Tracker (Lost Worlds)"
     },
+    "mode_ice_age": {
+      "display_name": "Map Tracker (Ice Age)"
+    },
+    "mode_ice_age_items_only": {
+      "display_name": "Item Tracker (Ice Age)"
+    },
     "vanilla_rando": {
       "display_name": "Map Tracker (Vanilla Rando)"
     },

--- a/mode_ice_age/layouts/components/bosses_grid.json
+++ b/mode_ice_age/layouts/components/bosses_grid.json
@@ -1,0 +1,44 @@
+{
+  "bosses_grid": {
+    "type": "array",
+    "orientation": "vertical",
+    "margin": "0,0",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "horizontal",
+        "margin": "0,0",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "1,1",
+            "rows": [
+              [
+                "yakraboss",
+                "yakraxiiiboss",
+                "dragontankboss",
+                "zomborboss",
+                "retiniteboss",
+                "heckranboss"
+              ],
+              [
+                "blacktyranoboss",
+                "rusttyranoboss",
+                "guardianboss",
+                "rseriesboss",
+                "masamuneboss",
+                "nizbelboss"
+              ],
+              [
+                "gigagaiaboss",
+                "motherbrainboss",
+                "sonofsunboss"
+              ]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mode_ice_age/layouts/components/items_grid.json
+++ b/mode_ice_age/layouts/components/items_grid.json
@@ -1,0 +1,59 @@
+{
+  "items_grid": {
+    "type": "array",
+    "orientation": "vertical",
+    "margin": "0,0",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "horizontal",
+        "margin": "0,0",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "1,1",
+            "rows": [
+              [
+                "crono",
+                "lucca",
+                "marle",
+                "frog",
+                "robo",
+                "ayla",
+                "magus"
+              ],
+              [
+                "benthilt",
+                "bentsword",
+                "masamune",
+                "grandleon",
+                "heromedal",
+                "roboribbon",
+                "validationcat"
+              ],
+              [
+                "gatekey",
+                "dreamstone",
+                "",
+                "prismshard",
+                "moonstone",
+                "jerky",
+                "jetsoftime"
+              ],
+              [
+                "pendant",
+                "",
+                "",
+                "tomapop",
+                "magic",
+                "gomode",
+                "checkcounter"
+              ]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/autotracking.lua
+++ b/scripts/autotracking.lua
@@ -73,30 +73,35 @@ function inGame()
 --
 function handleGoMode()
 
-  local gateKey = Tracker:FindObjectForCode("gatekey")
-  local dreamStone = Tracker:FindObjectForCode("dreamstone")
-  local rubyKnife = Tracker:FindObjectForCode("rubyknife")
-  local frog = Tracker:FindObjectForCode("glenn")
-  local magus = Tracker:FindObjectForCode("janus")
-  local hilt = Tracker:FindObjectForCode("benthilt")
-  local blade = Tracker:FindObjectForCode("bentsword")
-  local masa2 = Tracker:FindObjectForCode("grandleon")
-  local pendant = Tracker:FindObjectForCode("pendant")
-  local cTrigger = Tracker:FindObjectForCode("ctrigger")
-  local clone = Tracker:FindObjectForCode("clone")
+  local gateKey = Tracker:FindObjectForCode("gatekey").Active
+  local dreamStone = Tracker:FindObjectForCode("dreamstone").Active
+  local rubyKnife = Tracker:FindObjectForCode("rubyknife").Active
+  local frog = Tracker:FindObjectForCode("glenn").Active
+  local magus = Tracker:FindObjectForCode("janus").Active
+  local hilt = Tracker:FindObjectForCode("benthilt").Active
+  local blade = Tracker:FindObjectForCode("bentsword").Active
+  local pendant = Tracker:FindObjectForCode("pendant").Active
+  local cTrigger = Tracker:FindObjectForCode("ctrigger").Active
+  local clone = Tracker:FindObjectForCode("clone").Active
 
   local goMode
   if lostWorldsMode() then
     goMode =
-      (dreamStone.Active and rubyKnife.Active) or -- has ruby knife and can get to Black Tyrano
-      (cTrigger.Active and clone.Active) -- Death Peak -> Black Omen
+      (dreamStone and rubyKnife) or -- has ruby knife and can get to Black Tyrano
+      (cTrigger and clone) -- Death Peak -> Black Omen
   elseif legacyOfCyrusMode() then
-    goMode = frog.Active and magus.Active and hilt.Active and blade.Active and masa2.Active
+    local masa2 = Tracker:FindObjectForCode("grandleon").Active
+    goMode = frog and magus and hilt and blade and masa2
+  elseif iceAgeMode() then
+    local ayla = Tracker:FindObjectForCode("ayla").Active
+    local dactylChar =
+      Tracker:FindObjectForCode("@Dactyl Nest/Friend to the Dactyls").AvailableChestCount == 0
+    goMode = ayla and dactylChar and gateKey and dreamStone
   else
     goMode =
-      (gateKey.Active and dreamStone.Active and rubyKnife.Active) or -- 65 million BC -> 12000 BC -> Ocean Palace
-      (frog.Active and hilt.Active and blade.Active) or -- Magus' Castle -> 12000 BC -> Ocean Palace
-      (pendant.Active and cTrigger.Active and clone.Active) -- Death Peak -> Black Omen
+      (gateKey and dreamStone and rubyKnife) or -- 65 million BC -> 12000 BC -> Ocean Palace
+      (frog and hilt and blade) or -- Magus' Castle -> 12000 BC -> Ocean Palace
+      (pendant and cTrigger and clone) -- Death Peak -> Black Omen
   end
   local goButton = Tracker:FindObjectForCode("gomode")
   goButton.Active = goMode

--- a/scripts/init.lua
+++ b/scripts/init.lua
@@ -16,6 +16,9 @@ elseif lostWorldsMode() then
   items_grid_component = "lost_worlds/layouts/components/items_grid.json"
   bosses_grid_component = "lost_worlds/layouts/components/bosses_grid.json"
   flags_grid_component = "lost_worlds/layouts/components/flags_grid.json"
+elseif iceAgeMode() then
+  items_grid_component = "mode_ice_age/layouts/components/items_grid.json"
+  bosses_grid_component = "mode_ice_age/layouts/components/bosses_grid.json"
 elseif vanillaRandoMode() then
   items_grid_component = "vanilla_rando/layouts/components/items_grid.json"
 end

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -21,9 +21,34 @@ function notLostWorldsMode()
   return not lostWorldsMode()
 end
 
+-- Check if the tracker is in Ice Age mode
+function iceAgeMode()
+  return string.find(Tracker.ActiveVariantUID, "ice_age") ~= nil
+end
+
+function notIceAgeMode()
+  return not iceAgeMode()
+end
+
 -- Check if the tracker is in Vanilla Rando mode
 function vanillaRandoMode()
   return string.find(Tracker.ActiveVariantUID, "vanilla") ~= nil
+end
+
+function canAccessDarkAges()
+  if lostWorldsMode() then
+    return true
+  end
+
+  if iceAgeMode() then
+    local blackTyrano = Tracker:FindObjectForCode("blacktyranoboss").Active
+    return blackTyrano
+  end
+
+  local gateKey = Tracker:FindObjectForCode("gatekey").Active
+  local magusboss = Tracker:FindObjectForCode("magusboss").Active
+  local rseriesboss = Tracker:FindObjectForCode("rseriesboss").Active
+  return gateKey and rseriesboss and magusboss
 end
 
 function canAccessSealed()
@@ -66,6 +91,10 @@ function canAccessGiantsClaw()
 end
 
 function canAccessMagusCastle()
+  if iceAgeMode() then
+    return false
+  end
+
   local frog = Tracker:FindObjectForCode("frog").Active
   local masamune = Tracker:FindObjectForCode("masamune").Active
 
@@ -119,7 +148,7 @@ function canAccessOzzieFort()
 end
 
 function couldAccessOceanPalace()
-  return not legacyOfCyrusMode()
+  return not (legacyOfCyrusMode() or iceAgeMode())
 end
 
 function couldAccessTyranoCastle()


### PR DESCRIPTION
## Updates

* Adds support for Ice Age mode

## Testing

Rolled an Ice Age seed and played it (PopTracker over SNI to FXPak). Observed that "Go Mode" was properly enabled once I had Ayla, the Dactyl Nest character, Pendant, and Dreamstone.

![ice-age-run-gomode](https://github.com/coffeemancy/Jets-of-Time-Tracker/assets/3493534/5b58a099-cf78-48cc-8d0c-fb8473473a65)