### PR TITLE
Add support for Ice Age

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,23 @@ https://github.com/black-sliver/PopTracker#getting-started).
 
 This tracker pack includes several variants:
 
-* Item Tracker: item-only tracker for Standard mode
-* Item Tracker (Lost Worlds): item-only tracker for Lost Worlds mode
 * Map Tracker: item and map tracker for Standard mode
+* Item Tracker: item-only tracker for Standard mode
 * Map Tracker (Legacy of Cyrus): item and map tracker for Legacy of Cyrus mode
+* Item Tracker (Legacy of Cyrus): item-only tracker for Legacy of Cyrus mode
 * Map Tracker (Lost Worlds): item and map tracker for Lost Worlds mode
+* Item Tracker (Lost Worlds): item-only tracker for Lost Worlds mode
+* Map Tracker (Ice Age): item and map tracker for Ice Age mode
+* Item Tracker (Ice Age): item-only tracker for Ice Age mode
 * Map Tracker (Vanilla Rando): item and map tracker for Vanilla Rando mode
+* Item Tracker (Vanilla Rando): item-only tracker for Vanilla Rando mode
 
-Map Tracker variants allow for setting additional flags, such as Chronosanity
-and Epoch Fail. They also support "Broadcast View" (opens another smaller window
-with just the items).
+Each pack supports a "Broadcast View" which opens another smaller window
+with just the items, suitable for streaming.
+
+Additional flags (such as Chronosanity, Epoch Fail, etc.) can be enabled in
+the "Settings" popup. Most of these will only affect map trackers (adding
+additional spots to check or changing logic for location accessibility).
 
 ### Autotracking
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ v2.2.0
   - Consolidate all locations into single locations/locations.json
   - Mode-based logic in logic.lua
   - Componentize layouts using re-usable components for items, bosses, flags
+  - Add support for Ice Age mode
 
 v2.1.1
   - Removed embedded .zip file, moved to using Releases from Github

--- a/items/items.json
+++ b/items/items.json
@@ -4,49 +4,49 @@
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/crono.png",
-		"codes": "Crono"
+		"codes": "Crono,crono"
 	},
 	{
 		"name": "Lucca",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/lucca.png",
-		"codes": "Lucca"
+		"codes": "Lucca,lucca"
 	},
 	{
 		"name": "Nadia",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/marle.png",
-		"codes": "Marle,Nadia"
+		"codes": "Marle,Nadia,marle,nadia"
 	},
 	{
 		"name": "Glenn",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/frog.png",
-		"codes": "Frog,Glenn"
+		"codes": "Frog,Glenn,frog,glenn"
 	},
 	{
 		"name": "R66-Y",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/robo.png",
-		"codes": "Robo,R66-Y"
+		"codes": "Robo,R66-Y,robo"
 	},
 	{
 		"name": "Ayla",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/ayla.png",
-		"codes": "Ayla"
+		"codes": "Ayla,ayla"
 	},
 	{
 		"name": "Janus",
 		"type": "toggle",
 		"loop": "true",
 		"img": "images/magus.png",
-		"codes": "Magus,Janus"
+		"codes": "Magus,Janus,magus,janus"
 	},
 	{
 		"name": "Pendant",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -195,7 +195,7 @@
 			{
 				"name": "Dark Ages",
 				"color": "#c0c0c8",
-				"access_rules":["$lostWorldsMode", "gatekey", "rseriesboss", "magusboss"],
+				"access_rules":["$canAccessDarkAges"],
 				"children":
 				[
 					{
@@ -708,8 +708,7 @@
 					},
           {
 						"name": "Magic Cave",
-						"access_rules":
-            ["frog,masamune"],
+						"access_rules": ["$notIceAgeMode,frog,masamune"],
 						"sections":
 						[
               {

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,12 @@
     "lost_worlds_items_only": {
       "display_name": "Item Tracker (Lost Worlds)"
     },
+    "mode_ice_age": {
+      "display_name": "Map Tracker (Ice Age)"
+    },
+    "mode_ice_age_items_only": {
+      "display_name": "Item Tracker (Ice Age)"
+    },
     "vanilla_rando": {
       "display_name": "Map Tracker (Vanilla Rando)"
     },

--- a/mode_ice_age/layouts/components/bosses_grid.json
+++ b/mode_ice_age/layouts/components/bosses_grid.json
@@ -1,0 +1,44 @@
+{
+  "bosses_grid": {
+    "type": "array",
+    "orientation": "vertical",
+    "margin": "0,0",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "horizontal",
+        "margin": "0,0",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "1,1",
+            "rows": [
+              [
+                "yakraboss",
+                "yakraxiiiboss",
+                "dragontankboss",
+                "zomborboss",
+                "retiniteboss",
+                "heckranboss"
+              ],
+              [
+                "blacktyranoboss",
+                "rusttyranoboss",
+                "guardianboss",
+                "rseriesboss",
+                "masamuneboss",
+                "nizbelboss"
+              ],
+              [
+                "gigagaiaboss",
+                "motherbrainboss",
+                "sonofsunboss"
+              ]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mode_ice_age/layouts/components/items_grid.json
+++ b/mode_ice_age/layouts/components/items_grid.json
@@ -1,0 +1,59 @@
+{
+  "items_grid": {
+    "type": "array",
+    "orientation": "vertical",
+    "margin": "0,0",
+    "content": [
+      {
+        "type": "array",
+        "orientation": "horizontal",
+        "margin": "0,0",
+        "content": [
+          {
+            "type": "itemgrid",
+            "h_alignment": "center",
+            "item_margin": "1,1",
+            "rows": [
+              [
+                "crono",
+                "lucca",
+                "marle",
+                "frog",
+                "robo",
+                "ayla",
+                "magus"
+              ],
+              [
+                "benthilt",
+                "bentsword",
+                "masamune",
+                "grandleon",
+                "heromedal",
+                "roboribbon",
+                "validationcat"
+              ],
+              [
+                "gatekey",
+                "dreamstone",
+                "",
+                "prismshard",
+                "moonstone",
+                "jerky",
+                "jetsoftime"
+              ],
+              [
+                "pendant",
+                "",
+                "",
+                "tomapop",
+                "magic",
+                "gomode",
+                "checkcounter"
+              ]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/mode_ice_age_items_only
+++ b/mode_ice_age_items_only
@@ -1,0 +1,1 @@
+mode_ice_age

--- a/scripts/autotracking.lua
+++ b/scripts/autotracking.lua
@@ -64,30 +64,35 @@ function inGame()
 --
 function handleGoMode()
 
-  local gateKey = Tracker:FindObjectForCode("gatekey")
-  local dreamStone = Tracker:FindObjectForCode("dreamstone")
-  local rubyKnife = Tracker:FindObjectForCode("rubyknife")
-  local frog = Tracker:FindObjectForCode("glenn")
-  local magus = Tracker:FindObjectForCode("janus")
-  local hilt = Tracker:FindObjectForCode("benthilt")
-  local blade = Tracker:FindObjectForCode("bentsword")
-  local masa2 = Tracker:FindObjectForCode("grandleon")
-  local pendant = Tracker:FindObjectForCode("pendant")
-  local cTrigger = Tracker:FindObjectForCode("ctrigger")
-  local clone = Tracker:FindObjectForCode("clone")
+  local gateKey = Tracker:FindObjectForCode("gatekey").Active
+  local dreamStone = Tracker:FindObjectForCode("dreamstone").Active
+  local rubyKnife = Tracker:FindObjectForCode("rubyknife").Active
+  local frog = Tracker:FindObjectForCode("glenn").Active
+  local magus = Tracker:FindObjectForCode("janus").Active
+  local hilt = Tracker:FindObjectForCode("benthilt").Active
+  local blade = Tracker:FindObjectForCode("bentsword").Active
+  local pendant = Tracker:FindObjectForCode("pendant").Active
+  local cTrigger = Tracker:FindObjectForCode("ctrigger").Active
+  local clone = Tracker:FindObjectForCode("clone").Active
 
   local goMode
   if lostWorldsMode() then
     goMode =
-      (dreamStone.Active and rubyKnife.Active) or -- has ruby knife and can get to Black Tyrano
-      (cTrigger.Active and clone.Active) -- Death Peak -> Black Omen
+      (dreamStone and rubyKnife) or -- has ruby knife and can get to Black Tyrano
+      (cTrigger and clone) -- Death Peak -> Black Omen
   elseif legacyOfCyrusMode() then
-    goMode = frog.Active and magus.Active and hilt.Active and blade.Active and masa2.Active
+    local masa2 = Tracker:FindObjectForCode("grandleon").Active
+    goMode = frog and magus and hilt and blade and masa2
+  elseif iceAgeMode() then
+    local ayla = Tracker:FindObjectForCode("ayla").Active
+    local dactylChar =
+      Tracker:FindObjectForCode("@Dactyl Nest/Friend to the Dactyls").AvailableChestCount == 0
+    goMode = ayla and dactylChar and gateKey and dreamStone
   else
     goMode =
-      (gateKey.Active and dreamStone.Active and rubyKnife.Active) or -- 65 million BC -> 12000 BC -> Ocean Palace
-      (frog.Active and hilt.Active and blade.Active) or -- Magus' Castle -> 12000 BC -> Ocean Palace
-      (pendant.Active and cTrigger.Active and clone.Active) -- Death Peak -> Black Omen
+      (gateKey and dreamStone and rubyKnife) or -- 65 million BC -> 12000 BC -> Ocean Palace
+      (frog and hilt and blade) or -- Magus' Castle -> 12000 BC -> Ocean Palace
+      (pendant and cTrigger and clone) -- Death Peak -> Black Omen
   end
   local goButton = Tracker:FindObjectForCode("gomode")
   goButton.Active = goMode

--- a/scripts/autotracking.lua
+++ b/scripts/autotracking.lua
@@ -457,6 +457,12 @@ function updateEventsAndBosses(segment)
   updateBoss("nizbelboss", segment, 0x7F0105, 0x20)
   updateBoss("blacktyranoboss", segment, 0x7F00EC, 0x80)
 
+  event = updateEvent("@Dactyl Nest/Friend to the Dactyls", segment, 0x7F0160, 0x10)
+  if event and iceAgeMode() then
+    -- Getting the character at Dactyl Nest can trigger Go Mode for Ice Age
+    handleGoMode()
+  end
+
   -- Dark Ages
   updateBoss("gigagaiaboss", segment, 0x7F0100, 0x20)
   updateBoss("golemboss", segment, 0x7F0105, 0x80)
@@ -492,7 +498,6 @@ function updateEventsAndBosses(segment)
   if not itemsOnlyTracking() then
     -- Prehistory
     keyItemChecksDone = keyItemChecksDone + updateEvent("@Reptite Lair/Defeat Nizbel", segment, 0x7F0105, 0x20)
-    updateEvent("@Dactyl Nest/Friend to the Dactyls", segment, 0x7F0160, 0x10)
 
     -- Dark Ages
     keyItemChecksDone = keyItemChecksDone + updateEvent("@Mt Woe/Defeat Giga Gaia", segment, 0x7F0100, 0x20) -- same as boss flag

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -21,6 +21,15 @@ function notLostWorldsMode()
   return not lostWorldsMode()
 end
 
+-- Check if the tracker is in Ice Age mode
+function iceAgeMode()
+  return string.find(Tracker.ActiveVariantUID, "ice_age") ~= nil
+end
+
+function notIceAgeMode()
+  return not iceAgeMode()
+end
+
 -- Check if the tracker is in Vanilla Rando mode
 function vanillaRandoMode()
   return string.find(Tracker.ActiveVariantUID, "vanilla") ~= nil
@@ -29,6 +38,21 @@ end
 -- Check if the tracker variant is set to Items Only.
 function itemsOnlyTracking()
   return string.find(Tracker.ActiveVariantUID, "items_only") ~= nil
+end
+
+function canAccessDarkAges()
+  if lostWorldsMode() then
+    return true
+  end
+
+  if iceAgeMode() then
+    return Tracker:FindObjectForCode("blacktyranoboss").Active
+  end
+
+  local gateKey = Tracker:FindObjectForCode("gatekey").Active
+  local magusboss = Tracker:FindObjectForCode("magusboss").Active
+  local rseriesboss = Tracker:FindObjectForCode("rseriesboss").Active
+  return gateKey or rseriesboss or magusboss
 end
 
 function canAccessSealed()
@@ -71,6 +95,10 @@ function canAccessGiantsClaw()
 end
 
 function canAccessMagusCastle()
+  if iceAgeMode() then
+    return false
+  end
+
   local frog = Tracker:FindObjectForCode("frog").Active
   local masamune = Tracker:FindObjectForCode("masamune").Active
 
@@ -124,7 +152,7 @@ function canAccessOzzieFort()
 end
 
 function couldAccessOceanPalace()
-  return not legacyOfCyrusMode()
+  return not (legacyOfCyrusMode() or iceAgeMode())
 end
 
 function couldAccessTyranoCastle()


### PR DESCRIPTION
This PR adds support for Ice Age mode, following on from refactoring done in https://github.com/coffeemancy/Jets-of-Time-Tracker/pull/13 and https://github.com/coffeemancy/Jets-of-Time-Tracker/pull/17.

## Updates

* Adds support for Ice Age mode

## Testing

Rolled an Ice Age seed and played it (PopTracker over SNI to FXPak). Observed that "Go Mode" was properly enabled once I had Ayla, the Dactyl Nest character, Pendant, and Dreamstone.

Tested by collecting Dactyl Nest character last to make sure triggered Go Mode.

![ice-age-run-gomode](https://github.com/coffeemancy/Jets-of-Time-Tracker/assets/3493534/ed84671b-6177-4351-a5e3-ea01cfd6c6ad)
