### PR TITLE
Release tools and automation

### DIFF
--- a/.github/workflows/build-release-test.yaml
+++ b/.github/workflows/build-release-test.yaml
@@ -1,0 +1,25 @@
+# Job for testing build release changes on PRs.
+# NOTE: This file should be kept aligned with .github/workflows/build-release.yaml!
+---
+name: Test Build Release
+on:
+  push:
+    paths:
+      - .github/workflows/build-release-test.yaml
+      - tools/release.sh
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build release
+        run: |
+          ./tools/release.sh
+      - name: Archive release
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: |
+            *.zip
+          if-no-files-found: error

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,24 @@
+---
+name: Build Release
+on:
+  push:
+    branches:
+      - main
+      - master
+      - beta_integration
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build release
+        run: |
+          ./tools/release.sh
+      - name: Archive release
+        uses: actions/upload-artifact@v3
+        with:
+          name: release
+          path: |
+            *.zip
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,19 @@ automatically add the "All Eras" coordinates, overwriting the locations file:
 ./tools/normalize-locations.py -xi locations/locations.json
 ```
 
+### Release Automation
+
+The `tools/release.sh` tool can be used to build a zip file suiteable for PopTracker/EmoTracker.
+
+It builds a zip file which follows the exclusion rules per `.gitattributes` (like how
+`git archive` does), however, it also dereferences all symlinks, making copies of their linked
+files. It verifies the created artifact is a valid zip file.
+
+By default, it creates a zip file containing the short hash reference of the git ref it was
+built from. For release candidates and releases, a specific output file name can be specified.
+
+Usage details can be found by running `./tools/releas.sh -h`.
+
 ## Development
 
 For development, it is recommended to install python (3.11+) and lua with your system package manager.
@@ -40,6 +53,8 @@ There are several workflows defined in `.github/workflows`:
 
 * `luacheck.yaml`: runs [`luacheck`](https://luacheck.readthedocs.io/en/stable/) against .lua files
 * `jsontest.yaml`: runs [`pytest`](https://pytest.org) on tests in `tests/json/` against .json files
+* `lint-python.yaml`: runs [`flake8`](https://flake8.pycqa.org) against .py files
+* `build-release.yaml`: builds a release zip using `tools/release.sh`
 
 It is intended that Pull Requests pass these checks before being merged and released, to
 assure a measure of stability and quality with this repo.
@@ -70,12 +85,32 @@ have correct absolute map locations (e.g. for the "All Eras" map) based on each 
 coordinate. The `tools/normalize-locations.py` tool can produce a file which should pass
 these tests (the tests actually invoke this tools `--check` mode).
 
+#### `build-release.yaml`
+
+This workflow uses `tools/release.sh` to build a release zip, which would be suiteable
+for direct use by PopTracker/EmoTracker.
+
+It uses a GitHub Actions to [store workflow data as an artifact](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts).
+These temporary workflow artifacts are stored on GitHub for 90 days.
+
+When releasing a release candidate or release, the zip file built by this workflow
+can be downloaded, renamed, and uploaded and attached as part of the
+[Github Release](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts). Unlike
+the temporary artifacts created during the workflow, these will remain available to download from GitHub until manually
+deleted by a project maintainer.
+
 ## Releases
 
 The Github Releases mechanism is used to manually create tags/releases for users to download
 and use with PopTracker. The Releases archives all non-development-only files into .zip and
 .tar.gz for download using `git archive` (files can be excluded in `.gitattributes`).
-The intention is to direct users to the Releases page.
+However, that file is not directly usable in PopTracker/EmoTracker.
+
+The `tools/release.sh` script (described above) is used to create zip files which can be
+used directly in PopTracker/EmoTracker. The zip created with this script can be manually
+attached to Github Releases to provide a convenient means of distribution for PopTracker
+users and for EmoTracker users wishing to test newer updates (before rolling them out
+to the EmoTracker registry so they are downloaded in the app directly.)
 
 It is recommended to create tags (in the form of "vmajor.minor.patch", e.g. v2.1.1) along with
 each release, corresponding to bumping the version in `manifest.json` and the `changelog.txt`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ automatically add the "All Eras" coordinates, overwriting the locations file:
 
 ### Release Automation
 
-The `tools/release.sh` tool can be used to build a zip file suiteable for PopTracker/EmoTracker.
+The `tools/release.sh` tool can be used to build a zip file suitable for PopTracker/EmoTracker.
 
 It builds a zip file which follows the exclusion rules per `.gitattributes` (like how
 `git archive` does), however, it also dereferences all symlinks, making copies of their linked
@@ -32,7 +32,7 @@ files. It verifies the created artifact is a valid zip file.
 By default, it creates a zip file containing the short hash reference of the git ref it was
 built from. For release candidates and releases, a specific output file name can be specified.
 
-Usage details can be found by running `./tools/releas.sh -h`.
+Usage details can be found by running `./tools/release.sh -h`.
 
 ## Development
 
@@ -87,7 +87,7 @@ these tests (the tests actually invoke this tools `--check` mode).
 
 #### `build-release.yaml`
 
-This workflow uses `tools/release.sh` to build a release zip, which would be suiteable
+This workflow uses `tools/release.sh` to build a release zip, which would be suitable
 for direct use by PopTracker/EmoTracker.
 
 It uses a GitHub Actions to [store workflow data as an artifact](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts).
@@ -114,7 +114,7 @@ to the EmoTracker registry so they are downloaded in the app directly.)
 
 It is recommended to create tags (in the form of "vmajor.minor.patch", e.g. v2.1.1) along with
 each release, corresponding to bumping the version in `manifest.json` and the `changelog.txt`
-file with brief description of updates in this release. Test versions can use a "release candidate"
+file with brief description of end-user-impacting updates in this release. Test versions can use a "release candidate"
 suffix (e.g. v.2.1.1-rc0). Releases/tags are intended to be immutable (not overwritten).
 
 ### Local Release Artifacts

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,14 +1,8 @@
 v2.2.0
-  - Consolidate all locations into single locations/locations.json
-  - Mode-based logic in logic.lua
-  - Componentize layouts using re-usable components for items, bosses, flags
   - Add support for Ice Age mode
+  - Add support for vertical tracker orientation
 
 v2.1.1
-  - Removed embedded .zip file, moved to using Releases from Github
-  - Lua file whitespace cleanup and passing luacheck
-  - JSON files updated to follow strict JSON validation
-  - Added README.md with Usage notes
   - Fixed tracking equipped items to work with Duplicate Characters.
 
 v2.1.0

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# This script is used for building a zip file suiteable for PopTracker/Emotracker.
+# 
+# It builds a zip file which abides excluding files per .gitattributes (like git archive)
+# but dereferences all symlinks (making copies of their linked files).
+
+set -euo pipefail
+
+CWD="$(builtin pwd)"
+GIT_ROOT="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")"/.. && builtin pwd)"
+
+function cleanup {
+  ret=$?
+  if [[ -z "${SKIP_CLEANUP:-}" ]]; then
+    if [[ -n "${TEMP_DIR:-}" ]]; then 
+      rm -rf "${TEMP_DIR}"
+    fi
+  else
+    if [[ -n "${TEMP_DIR:-}" ]]; then 
+      echo "Skipping cleanup of temporary files in ${TEMP_DIR}"
+    fi
+  fi
+  exit $ret
+}
+
+trap cleanup EXIT
+
+function preflight {
+  # assure that tools used by this script are installed
+  commands=(git tar zip unzip)
+  for cmd in "${commands[@]}"; do
+    if ! command -v "$cmd" > /dev/null; then
+      >&2 echo "This script requires $cmd!"
+      exit 1
+    fi
+  done 
+
+  if [[ -z "${RELEASE_ZIP}" ]]; then
+    # if no specified name, generate a zip name
+    RELEASE_ZIP="Jets-of-Time-Tracker-$(git rev-parse --short HEAD).zip"
+    export RELEASE_ZIP
+  fi
+
+  # check if release zip already exists and prompt to overwrite
+  if [[ -e "${RELEASE_ZIP}" ]]; then
+    if [[ -n "${YES}" ]]; then
+      echo "Overwriting existing ${RELEASE_ZIP}"
+    else
+      read -p "Overwrite existing ${RELEASE_ZIP}? [y/N] " -n 1 -r
+      if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then exit 0; fi
+      echo
+    fi
+  fi
+}
+
+function build_release {
+  echo "Building release ${RELEASE_ZIP}"
+
+  TEMP_DIR="${TEMP_DIR:-$(mktemp -d)}"
+  export TEMP_DIR
+  echo "* Building in ${TEMP_DIR}"
+
+  # create an archive just to get a list of files that abides .gitattributes
+  echo "* Creating git archive"
+  cd "$GIT_ROOT" || (echo "Can't change to $GIT_ROOT directory!" && exit 1)
+  git archive HEAD --format=tar -o "${TEMP_DIR}/archive.tar"
+
+  # use list of non-directory files from initial archive tarball to produce a new tar
+  # with symlinks dereferenced into copies, so can with EmoTracker
+  echo "* Creating dereferenced tarball"
+  tar -tf "${TEMP_DIR}/archive.tar" | grep -v '/$' > "${TEMP_DIR}/files.txt"
+  tar -chf "${TEMP_DIR}/release.tar.gz" -T "${TEMP_DIR}/files.txt"
+
+  # extract the new tar and zip it up
+  echo "* Building release zip"
+  cd "${TEMP_DIR}"
+  rm -rf zip
+  mkdir zip
+  cd zip
+  tar -xf ../release.tar.gz
+  zip -q -r ../release.zip .
+  cd "${CWD}"
+  cp "${TEMP_DIR}/release.zip" "${RELEASE_ZIP}"
+
+  # verify zip
+  echo "* Verifying release zip"
+  unzip -qt "${RELEASE_ZIP}" > /dev/null
+
+  echo "Created release: ${RELEASE_ZIP}"
+}
+
+function usage {
+  echo "./tools/release.sh [-o] [-y]"
+  echo
+  echo "-h     print this help"
+  echo "-o     output zip filename to use"
+  echo "-y     do not prompt (overwrites release zip)"
+}
+
+RELEASE_ZIP="${RELEASE_ZIP:-}"
+YES="${YES:-}"
+while getopts 'ho:y' flag; do
+  case "${flag}" in
+    h)
+      usage
+      exit 0
+      ;;
+    o)
+      RELEASE_ZIP="${OPTARG}"
+      ;;
+    y)
+      YES=1
+      ;;
+    *)
+      usage
+      exit 1
+  esac
+done
+export RELEASE_ZIP YES
+export YES
+
+preflight
+build_release

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# This script is used for building a zip file suiteable for PopTracker/Emotracker.
+# This script is used for building a zip file suitable for PopTracker/Emotracker.
 # 
 # It builds a zip file which abides excluding files per .gitattributes (like git archive)
 # but dereferences all symlinks (making copies of their linked files).


### PR DESCRIPTION
This PR adds tooling for automating creation of zip files for PopTracker/EmoTracker which can be attached to a Github Release and used in EmoTracker repositories.

## Updates

* Adds `tools/release.sh` to create a directly-usable zip file for PopTracker/EmoTracker which contains all the pack files with symlinks dereferenced
* Builds a release on pushes to certain branches
* Tests the release tooling itself when the script is updated

## Testing

[Ran on this PR!](https://github.com/coffeemancy/Jets-of-Time-Tracker/actions/runs/6062576733)

Building artifact:

![release-tool-run](https://github.com/coffeemancy/Jets-of-Time-Tracker/assets/3493534/7cc68bd3-cbaa-41dc-bb9f-754ec8d82729)

Artifact attached:

![release-tool-artifact](https://github.com/coffeemancy/Jets-of-Time-Tracker/assets/3493534/e53df81e-db44-4fc6-a548-f4e8557424a7)

Artifact: https://github.com/coffeemancy/Jets-of-Time-Tracker/suites/15768849641/artifacts/900009934

The zip created itself has the zip release inside of it:

![release-tool-zip-extract](https://github.com/coffeemancy/Jets-of-Time-Tracker/assets/3493534/5954c74a-0767-427e-b3e9-12f55ff99653)

(This is a [known limitation of the upload action](https://github.com/actions/upload-artifact#zipped-artifact-downloads) but should work fine.)